### PR TITLE
Refactor FileService and update file handling logic

### DIFF
--- a/RoyAppMaui.Tests/Services/FileServiceTests.cs
+++ b/RoyAppMaui.Tests/Services/FileServiceTests.cs
@@ -1,5 +1,3 @@
-using CommunityToolkit.Maui.Storage;
-
 using FakeItEasy;
 
 using RoyAppMaui.Extensions;
@@ -26,9 +24,7 @@ public class FileServiceTests
             { filePath, new MockFileData(fileContent) }
         });
 
-        var fileSaver = A.Fake<IFileSaver>();
-        var filePicker = A.Fake<IFilePicker>();
-        var service = new FileService(fileSystem, fileSaver, filePicker);
+        var service = new FileService(fileSystem);
 
         // Act
         var result = service.GetSleepDataFromCsv(filePath);
@@ -49,10 +45,7 @@ public class FileServiceTests
         // Arrange
         var filePath = "nonexistent.csv";
         var fileSystem = new MockFileSystem();
-
-        var fileSaver = A.Fake<IFileSaver>();
-        var filePicker = A.Fake<IFilePicker>();
-        var service = new FileService(fileSystem, fileSaver, filePicker);
+        var service = new FileService(fileSystem);
 
         // Act
         var result = service.GetSleepDataFromCsv(filePath);
@@ -72,9 +65,7 @@ public class FileServiceTests
         {
             { filePath, new MockFileData(fileContent) }
         });
-        var fileSaver = A.Fake<IFileSaver>();
-        var filePicker = A.Fake<IFilePicker>();
-        var service = new FileService(fileSystem, fileSaver, filePicker);
+        var service = new FileService(fileSystem);
 
         // Act
         var result = service.GetSleepDataFromCsv(filePath);
@@ -92,9 +83,7 @@ public class FileServiceTests
         var fileSystem = A.Fake<System.IO.Abstractions.IFileSystem>();
         A.CallTo(() => fileSystem.File.OpenRead(A<string>._)).Throws(new Exception("Something went wrong"));
 
-        var fileSaver = A.Fake<IFileSaver>();
-        var filePicker = A.Fake<IFilePicker>();
-        var service = new FileService(fileSystem, fileSaver, filePicker);
+        var service = new FileService(fileSystem);
 
         // Act
         var result = service.GetSleepDataFromCsv(filePath);

--- a/RoyAppMaui/RoyAppMaui.csproj
+++ b/RoyAppMaui/RoyAppMaui.csproj
@@ -44,6 +44,36 @@
     <AppInstallerUri>\\diskstation\homes\rtdubar\RoyApp</AppInstallerUri>
     <HoursBetweenUpdateChecks>168</HoursBetweenUpdateChecks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0|AnyCPU'">
+    <NoWarn>CA1416;1701;17024</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-android|AnyCPU'">
+    <NoWarn>CA1416;1701;17024</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-ios|AnyCPU'">
+    <NoWarn>CA1416;1701;17024</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-maccatalyst|AnyCPU'">
+    <NoWarn>CA1416;1701;17024</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-windows10.0.19041.0|AnyCPU'">
+    <NoWarn>CA1416;1701;17024</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0|AnyCPU'">
+    <NoWarn>CA1416;1701;17024</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-android|AnyCPU'">
+    <NoWarn>CA1416;1701;17024</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-ios|AnyCPU'">
+    <NoWarn>CA1416;1701;17024</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-maccatalyst|AnyCPU'">
+    <NoWarn>CA1416;1701;17024</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-windows10.0.19041.0|AnyCPU'">
+    <NoWarn>CA1416;1701;17024</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <!-- App Icon -->
     <MauiIcon Include="Resources\AppIcon\appicon.svg" Color="#00FF0000" />

--- a/RoyAppMaui/Services/IFileService.cs
+++ b/RoyAppMaui/Services/IFileService.cs
@@ -6,6 +6,5 @@ namespace RoyAppMaui.Services;
 public interface IFileService
 {
     Result<List<Sleep>> GetSleepDataFromCsv(string filePath);
-    Task<bool> SaveDataToFile(IEnumerable<Sleep> sleeps);
-    Task<FileResult?> SelectImportFile();
+    byte[] GetExportData(IEnumerable<Sleep> sleeps);
 }

--- a/RoyAppMaui/Types/FilePickerTypes.cs
+++ b/RoyAppMaui/Types/FilePickerTypes.cs
@@ -1,0 +1,16 @@
+﻿namespace RoyAppMaui.Types;
+public static class FilePickerTypes
+{
+    public static FilePickerFileType? GetFilePickerFileTypes()
+    {
+        return new FilePickerFileType(
+            new Dictionary<DevicePlatform, IEnumerable<string>>
+            {
+                { DevicePlatform.iOS, ["public.comma-separated-values-text"] },
+                { DevicePlatform.Android, ["text/comma-separated-values"] },
+                { DevicePlatform.WinUI, [".csv"] },
+                { DevicePlatform.Tizen, ["*/*"] },
+                { DevicePlatform.macOS, ["UTType.commaSeparatedText"] }
+            });
+    }
+}

--- a/RoyAppMaui/Types/FilePickerTypes.cs
+++ b/RoyAppMaui/Types/FilePickerTypes.cs
@@ -1,4 +1,5 @@
 ﻿namespace RoyAppMaui.Types;
+[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage(Justification = "No logic to test here")]
 public static class FilePickerTypes
 {
     public static FilePickerFileType? GetFilePickerFileTypes()


### PR DESCRIPTION
Refactor FileService and update file handling logic

- Removed dependencies on IFileSaver and IFilePicker from FileService, simplifying its constructor and related tests.
- Injected IFilePicker and IFileSaver into SleepTable.razor.cs, adding methods for file selection and saving.
- Modified GetExportData to return a byte array for more efficient file saving, updating CSV export logic.
- Introduced a new static class FilePickerTypes for better organization of file picker type definitions.
- Updated .csproj to suppress specific warnings for various build configurations.
- Removed unused methods related to file saving and importing from FileService.